### PR TITLE
Add more precision on TooltipCaption & TooltipName

### DIFF
--- a/STInstallerBuilder/README.md
+++ b/STInstallerBuilder/README.md
@@ -10,8 +10,8 @@ The startify control panel app, changes these settings from a gui, and then when
     -   DockedDesign (bool) - This toggles between floating and docked start menu style. 
     - DisplayTiles (bool) - Display or hide tiles part of the start menu
     - Show*Button (bool) - Displays or hides the respective button in left bar of the start menu.
-    - TooltipCaption (string) - Tooltip caption to search for when hooking the Start Button
-    - TooltipName (string) - Tooltip Window name to search for when hooking the Start Button
+    - TooltipCaption (string) - Tooltip caption to search for when hooking the Start Button (This should be Start, in your OS' language (example: "Démarrer" if using a French language pack))
+    - TooltipName (string) - Tooltip Window name to search for when hooking the Start Button (Internally used as the window class, should be "Start", even on non-English systems)
  
       Be careful about the two last ones if you are using any other language than English or Polish
 


### PR DESCRIPTION
TooltipName is internally referenced as the Start menu's class for searching, and remains "Start", even on non-English systems.

## Some proof
### Spy++
![image](https://github.com/user-attachments/assets/a6eab8cc-ce5b-4d24-bd21-0d36228911cd)
Spy++, displaying the Start button window as "Démarrer" (title), "Start" (window class) on a French OS

### The declaration's name in the source code
https://github.com/Lixkote/Startify/blob/fca14ddc09b19c114ddf0280dd8de937db1054e2/BackEnd/Helpers/WinButtonHook.cs#L99